### PR TITLE
Update gts-4-util-sequelize-options.js

### DIFF
--- a/src/gts-4-util-sequelize-options.js
+++ b/src/gts-4-util-sequelize-options.js
@@ -39,7 +39,6 @@ export default class gtsUtilSequelizeOptions {
             if (typeof args.where !== "object")
                 throw new Error("invalid \"where\" argument (object expected)")
             opts.where = args.where
-            opts.where = {}
             Object.keys(args.where).forEach((field) => {
                 if (!allowed.attribute[field])
                     throw new Error("invalid \"where\" argument: " +
@@ -93,7 +92,6 @@ export default class gtsUtilSequelizeOptions {
             if (typeof args.where !== "object")
                 throw new Error("invalid \"where\" argument (object expected)")
             opts.where = args.where
-            opts.where = {}
             Object.keys(args.where).forEach((field) => {
                 if (!allowed.attribute[field])
                     throw new Error("invalid \"where\" argument: " +


### PR DESCRIPTION
Removed lines with `opts.where = {}` after `args.where` was assigned.